### PR TITLE
add: doc for react build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ To start the server, visit [babel-sandbox-server](https://github.com/MLH-Fellows
 
 ### Directory structure:
 ```
-/public 	
-/src 
-	/components
-	/helpers
+<big><pre>
+📂 [public](./public) # Supplemental assets or resources, or static files
+📂 [src](./src) # Source files
+├── 📂 [components](./src/components) 
+</pre></big>
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ To start the server, visit [babel-sandbox-server](https://github.com/MLH-Fellows
 ```
 /public 	
 /src 
-	/components 				
-	/reducers
+	/components
 	/helpers
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+## Babel Sandbox
+
+### Quick start:
+
+- Install dependencies `yarn install` or `npm install`
+- Start front-end `yarn start` or `npm start`
+    - Output: Web page using `localhost:3000` should open
+
+To start the server, visit [babel-sandbox-server](https://github.com/MLH-Fellowship/babel-sandbox-server) and follow the steps in [Quick Start](https://github.com/MLH-Fellowship/babel-sandbox-server#quick-start).
+
+### Directory structure:
+```
+/public 	
+/src 
+	/components 				
+	/reducers
+	/helpers
+```
+

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@
 To start the server, visit [babel-sandbox-server](https://github.com/MLH-Fellowship/babel-sandbox-server) and follow the steps in [Quick Start](https://github.com/MLH-Fellowship/babel-sandbox-server#quick-start).
 
 ### Directory structure:
-```
 <big><pre>
 📂 [public](./public) # Supplemental assets or resources, or static files
 📂 [src](./src) # Source files
 ├── 📂 [components](./src/components) 
 </pre></big>
-```


### PR DESCRIPTION
Addresses #24 with a basic readme.md that includes running the repo and file structure. 

Additions to the file structure include: 
- reducers (i.e. `reducer.js`)
- helpers (i.e. `reduxHelpers.js`) 