### PR TITLE
Configure app for deployment within sails

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-scripts": "3.4.1",
     "semantic-ui-less": "^2.4.1"
   },
+  "homepage": "/app",
   "browserslist": {
     "production": [
       "edge 16"

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
       margin: 0;
     }
   </style>
-  <link rel="stylesheet" href="/material.css" />
-  <link rel="stylesheet" href="/codemirror.css" />
+  <link rel="stylesheet" href="material.css" />
+  <link rel="stylesheet" href="codemirror.css" />
 </head>
 
 <body>


### PR DESCRIPTION
This pull sets the project production base directory to `/babel-sandbox-server/assets/app`, allowing us to serve it with sails, meaning we can server everything in production with Heroku.

- Cons
    - put the server in charge of client deployments
    - require the server to make a commit to deploy a client (think about roll backs)

- Pros
    - save us from having two deployment processes
    - save time (it's done now)
    - still loosely coupled, each project can still run independently 
    - cheapest option
    - I think it's easy to understand

Assuming both repos are siblings:

```
/babel-sandbox-server
/babel-sandbox
```

The following shell script will build the project and then copy it to the static folder of [the sails app](http://github.com/mlh-fellowship/babel-sandbox-server). It can then be served with `sails lift`.

`babel-sandbox/copy-assets.sh`
```sh
yarn build
cp -R build/. ../babel-sandbox-server/assets/app
```

Then sails would have the assets:

```sh
cd ../babel-sandbox-server
sails lift
```

In Heroku, it's easy to set up deployments based on `git push`. Meaning, we can modify this script to:

`build-assets-and-deploy.sh`
```sh
./copy-assets.sh
git commit -am "Update client and deploy"
git push origin master
echo "heroku will now deploy master"
```

I typically use shell scripts in my projects, but there are a few other ways to do this:

- keep deployments separate (netlify and heroku)
- deploy to github pages
- something like [https://github.com/lerna/lerna](https://github.com/lerna/lerna)
- do it as a sails script