### PR TITLE
Allow restorations with no plugins. 

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -77,7 +77,13 @@ function registerDefaultPlugins() {
   );
 }
 
-export const App = ({ defaultSource, defaultConfig, defCustomPlugin, defaultId, defaultForks }) => {
+export const App = ({
+  defaultSource,
+  defaultConfig,
+  defCustomPlugin,
+  defaultId,
+  defaultForks,
+}) => {
   const [source, setSource] = React.useState(defaultSource);
   const [enableCustomPlugin, toggleCustomPlugin] = React.useState(false);
   const [customPlugin, setCustomPlugin] = React.useState(defCustomPlugin);
@@ -127,14 +133,11 @@ export const App = ({ defaultSource, defaultConfig, defCustomPlugin, defaultId, 
   }, [debouncedSource]);
 
   useEffect(() => {
-
     if (editorRef && editorRef.current && cursorAST.anchor && cursorAST.head) {
-
       editorRef.current.editor.setSelection(cursorAST.anchor, cursorAST.head, {
         scroll: false,
       });
     }
-
   }, [editorRef, cursorAST]);
 
   importDefaultPlugins();
@@ -160,7 +163,8 @@ export const App = ({ defaultSource, defaultConfig, defCustomPlugin, defaultId, 
 
       <Grid celled="internally">
         {forksVisible && <Forks forks={forks} />}
-        <Input size={size}
+        <Input
+          size={size}
           gzip={gzip}
           source={source}
           ref={editorRef}
@@ -169,7 +173,8 @@ export const App = ({ defaultSource, defaultConfig, defCustomPlugin, defaultId, 
           size={size}
           gzip={gzip}
           source={source}
-          setSource={setSource} />
+          setSource={setSource}
+        />
         {enableCustomPlugin && (
           <CustomPlugin
             toggleCustomPlugin={toggleCustomPlugin}

--- a/src/components/ForkModal.js
+++ b/src/components/ForkModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import {Button, Modal} from "semantic-ui-react";
+import { Button, Modal } from "semantic-ui-react";
 
 export function ForkModal({ trigger, onFork }) {
   const [open, setOpen] = useState(false);

--- a/src/state/REPLState.js
+++ b/src/state/REPLState.js
@@ -81,7 +81,7 @@ class REPLState {
       decodeBase64(jsonState.base64PluginKey),
       jsonState.configIDs.map(configs => {
         return decodeBase64(configs);
-      }),
+      })
     );
   }
 
@@ -101,7 +101,9 @@ class REPLState {
       }
 
       // https://stackoverflow.com/questions/6941533/get-protocol-domain-and-port-from-url
-      return window.location.href.split("/").slice(0, 3).join("/") + message.url
+      return (
+        window.location.href.split("/").slice(0, 3).join("/") + message.url
+      );
     } catch (err) {
       console.error(err);
       return err;
@@ -166,7 +168,7 @@ class REPLState {
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",
-        }
+        },
       });
       return resp.json();
     } catch (err) {
@@ -177,7 +179,7 @@ class REPLState {
 
   /**
    * REPLState.GetBlob returns the blob given a unique identifier
-   * @param {string} ID 
+   * @param {string} ID
    * @return {Promise<Object>}
    */
   static async GetBlob(ID) {
@@ -212,7 +214,6 @@ class REPLState {
       return null;
     }
   }
-
 }
 
 export default REPLState;

--- a/src/state/REPLState.js
+++ b/src/state/REPLState.js
@@ -77,10 +77,10 @@ class REPLState {
   static Decode(encodedState) {
     let jsonState = JSON.parse(encodedState);
     return new REPLState(
-      decodeBase64(jsonState.base64SourceKey),
-      decodeBase64(jsonState.base64PluginKey),
+      decodeBase64(jsonState.base64SourceKey || ""),
+      decodeBase64(jsonState.base64PluginKey || ""),
       jsonState.configIDs.map(configs => {
-        return decodeBase64(configs);
+        return decodeBase64(configs || "");
       })
     );
   }


### PR DESCRIPTION
This PR should fix #96 by using the `||` operator. Passing null to `{decode,encode}Base64` causes the error described in the issue. Using the `||` we can always pass an empty string in the case the plugin isn't there. 