### PR TITLE
Change request URLs for production build

### DIFF
--- a/src/state/REPLState.js
+++ b/src/state/REPLState.js
@@ -1,3 +1,5 @@
+const baseURL = process.env.NODE_ENV === "production" ? `https://babel-sandbox.herokuapp.com`: ''
+
 // convert a Unicode string to a string in which
 // each 16-bit unit occupies only one byte
 // source: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa
@@ -150,7 +152,7 @@ class REPLState {
    * @returns {Promise<Object>} Blob representing the current state.
    */
   async New() {
-    const url = `/api/v1/blobs/create`;
+    const url = baseURL + `/api/v1/blobs/create`;
 
     try {
       const resp = await fetch(url, {
@@ -174,7 +176,7 @@ class REPLState {
    * @returns {Promise<Object>} Blob representing the current state.
    */
   async Save(ID) {
-    const url = `/api/v1/blobs/update/${ID}`;
+    const url = baseURL + `/api/v1/blobs/update/${ID}`;
     try {
       const resp = await fetch(url, {
         method: "PUT",
@@ -197,7 +199,7 @@ class REPLState {
    * @returns {Promise<Object>} Blob representing the new fork
    */
   async Fork(ID) {
-    const url = `/api/v1/blobs/fork/${ID}`;
+    const url = baseURL + `/api/v1/blobs/fork/${ID}`;
     try {
       const resp = await fetch(url, {
         method: "POST",
@@ -219,7 +221,7 @@ class REPLState {
    * @return {Promise<Object>}
    */
   static async GetBlob(ID) {
-    const url = `/api/v1/blobs/${ID}`;
+    const url = baseURL + `/api/v1/blobs/${ID}`;
     try {
       const resp = await fetch(url);
       const json = await resp.json();
@@ -236,7 +238,7 @@ class REPLState {
    * @returns {Promise<REPLState | null>}
    */
   static async FromID(ID) {
-    const url = `/api/v1/blobs/${ID}`;
+    const url = baseURL + `/api/v1/blobs/${ID}`;
     try {
       const resp = await fetch(url);
       const text = await resp.text();


### PR DESCRIPTION
This PR adds changes the request URL for the production build. `npm start` still works as expected, as in [`proxy`](https://github.com/MLH-Fellowship/babel-sandbox/blob/master/package.json#L5) is still used as the base URL for requests made in the dev env