### PR TITLE
Switch to using /#/:share instead of /:share

### DIFF
--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -81,7 +81,7 @@ export function MainMenu({
                 window.history.replaceState(
                   null,
                   "Babel Test Playground",
-                  `/share/${blob.id}`
+                  `#/share/${blob.id}`
                 );
               } else {
                 // If it does, update the blob
@@ -108,7 +108,7 @@ export function MainMenu({
                   window.history.replaceState(
                     null,
                     "Babel Test Playground",
-                    `/share/${linkId}`
+                    `#/share/${linkId}`
                   );
                 }}
               >
@@ -135,7 +135,7 @@ export function MainMenu({
                 window.history.replaceState(
                   null,
                   "Babel Test Playground",
-                  `/share/${fork.id}`
+                  `#/share/${fork.id}`
                 );
               }}
               trigger={

--- a/src/state/detectShare.js
+++ b/src/state/detectShare.js
@@ -3,14 +3,15 @@
  * @returns {boolean}
  */
 function isShareLink() {
-  const path = window.location.pathname;
+  const path = window.location.hash;
   const shareIndicator = "share";
   return path.includes(shareIndicator);
 }
 
 function extractID() {
+
   // Attempt to capture :key from http://example.com/share/:key/
-  const pathParts = window.location.pathname.split("/");
+  const pathParts = window.location.hash.split("/");
   if (pathParts[1] === "share" && pathParts[2]) {
     return pathParts[2];
   } else {
@@ -18,6 +19,7 @@ function extractID() {
       "Trying to extract ID from a share link that doesn't have one."
     );
   }
+
 }
 
 export { isShareLink, extractID };


### PR DESCRIPTION
Netlify was having trouble with the raw `/share` links. This uses an anchor/hash to instruct Netlify not to try to route into a new directory.

`/share/id` becomes `/#/share/id`.

Depends on https://github.com/MLH-Fellowship/babel-sandbox-server/pull/20