### PR TITLE
Cloning configs

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -89,6 +89,12 @@ export const App = ({
           render: () => (
             <Output
               babelConfig={config}
+              cloneConfig={() => {
+                setJsonConfig(configs => [
+                  ...configs,
+                  config
+                ])
+              }}
               enableCustomPlugin={enableCustomPlugin}
               customPlugin={customPlugin}
               updateBabelConfig={updateBabelConfig}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -92,7 +92,8 @@ export const App = ({
               cloneConfig={() => {
                 setJsonConfig(configs => [
                   ...configs,
-                  config
+                  // Deep copy of config
+                  JSON.parse(JSON.stringify(config)),
                 ])
               }}
               enableCustomPlugin={enableCustomPlugin}

--- a/src/components/CompiledOutput.js
+++ b/src/components/CompiledOutput.js
@@ -24,6 +24,7 @@ export function CompiledOutput({
   source,
   customPlugin,
   config,
+  cloneConfig,
   onConfigChange,
   removeConfig,
   cursor,
@@ -245,6 +246,10 @@ export function CompiledOutput({
                     setTimeTravelIndex(timeTravelIndex + 1);
                   }
                 }}
+              />
+              <Button
+                content="Clone"
+                onClick={cloneConfig}
               />
             </Menu.Menu>
           </Menu>

--- a/src/components/Output.js
+++ b/src/components/Output.js
@@ -3,6 +3,7 @@ import { CompiledOutput } from "./CompiledOutput";
 
 export function Output({
   babelConfig,
+  cloneConfig,
   debouncedSource,
   enableCustomPlugin,
   customPlugin,
@@ -17,6 +18,7 @@ export function Output({
       source={debouncedSource}
       customPlugin={enableCustomPlugin ? customPlugin : undefined}
       config={babelConfig}
+      cloneConfig={cloneConfig}
       onConfigChange={config => updateBabelConfig(config, index)}
       removeConfig={() => removeBabelConfig(index)}
       cursor={debouncedCursor}


### PR DESCRIPTION
Closes #114.

This PR adds a "Clone" button that allows the user to clone the current config into another tab. The new config can then be modified independently from the original.

I'm not sure if this is where we want to put the clone button, but it can be easily moved if needed
![image](https://user-images.githubusercontent.com/10204169/90592068-8f618400-e199-11ea-8e25-7fb535c1298d.png)
